### PR TITLE
Hide "show column in bugzilla" button from collapsed columns

### DIFF
--- a/data/kanbugger.css
+++ b/data/kanbugger.css
@@ -38,3 +38,7 @@
     font-size: 11px !important;
     line-height: 16px !important;
 }
+
+.column-view.minimized a.bz {
+    display: none;
+}


### PR DESCRIPTION
Fixes issue at https://github.com/Sancus/kanbugger/issues/19
